### PR TITLE
Fix "already mutably borrowed" error

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -414,7 +414,7 @@ pub mod service_account {
 
             if jwt_update_expiry_if(&mut jwt, 50) {
                 if let Some(secret) = self.credentials.keys.secret.as_ref() {
-                    if let Ok(v) = self.jwt.borrow().encode(&secret.deref()) {
+                    if let Ok(v) = jwt.encode(&secret.deref()) {
                         if let Ok(v2) = v.encoded() {
                             self.access_token_.swap(&RefCell::new(v2.encode()));
                         }


### PR DESCRIPTION
Locally when the server runs for 50 minutes, it crashes with this error. I tested the fix by changing 50 to 1 and printing a `warn!` inside the innermost if-statement, and saw it get logged to the console.

```
thread 'main' panicked at 'already mutably borrowed: BorrowError', /Users/vbeffa/.cargo/git/checkouts/firestore-db-and-auth-rs-b59eba162a2ae5a2/fd31571/src/sessions.rs:417:45
stack backtrace:
   0:        0x104e05474 - std::backtrace_rs::backtrace::libunwind::trace::hf5e0f1b56dda01d5
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/../../backtrace/src/backtrace/libunwind.rs:90:5
   1:        0x104e05474 - std::backtrace_rs::backtrace::trace_unsynchronized::he30181384dfc443b
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x104e05474 - std::sys_common::backtrace::_print_fmt::h70a4be95a22f8da9
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/sys_common/backtrace.rs:67:5
   3:        0x104e05474 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h36c0052c0225805d
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/sys_common/backtrace.rs:46:22
   4:        0x104e2540c - core::fmt::write::h53cd30d79330b217
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/fmt/mod.rs:1110:17
   5:        0x104dfe53a - std::io::Write::write_fmt::h621fe9764d072270
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/io/mod.rs:1588:15
   6:        0x104e0739f - std::sys_common::backtrace::_print::h49b875dc59021a4e
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/sys_common/backtrace.rs:49:5
   7:        0x104e0739f - std::sys_common::backtrace::print::h929e04ec4b5d0531
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/sys_common/backtrace.rs:36:9
   8:        0x104e0739f - std::panicking::default_hook::{{closure}}::h497f77d12f011aa3
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/panicking.rs:208:50
   9:        0x104e06e9d - std::panicking::default_hook::h1ccb84eb2bce8b2a
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/panicking.rs:225:9
  10:        0x104e07a80 - std::panicking::rust_panic_with_hook::h151c17db51726319
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/panicking.rs:622:17
  11:        0x104e07545 - std::panicking::begin_panic_handler::{{closure}}::he5700381c5850965
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/panicking.rs:519:13
  12:        0x104e058e8 - std::sys_common::backtrace::__rust_end_short_backtrace::h25a79dc02eedace7
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/sys_common/backtrace.rs:141:18
  13:        0x104e074aa - rust_begin_unwind
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/panicking.rs:515:5
  14:        0x104e451ff - core::panicking::panic_fmt::hdc889aaa86870f3d
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/panicking.rs:92:14
  15:        0x104e452e5 - core::result::unwrap_failed::h0f7e23743d6feb49
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/result.rs:1355:5
  16:        0x1042c8c2b - core::result::Result<T,E>::expect::h03bfbd047dd248fa
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/result.rs:997:23
  17:        0x1042dca9a - core::cell::RefCell<T>::borrow::h074d75a5ba4b5ea1
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/cell.rs:821:9
  18:        0x10431ee38 - <firestore_db_and_auth::sessions::service_account::Session as firestore_db_and_auth::FirebaseAuthBearer>::access_token::hd4dbf826896e0dea
                               at /Users/vbeffa/.cargo/git/checkouts/firestore-db-and-auth-rs-b59eba162a2ae5a2/fd31571/src/sessions.rs:417:36
  19:        0x103d3770b - firestore_db_and_auth::documents::delete::delete::hb8b891da3dd68b90
                               at /Users/vbeffa/.cargo/git/checkouts/firestore-db-and-auth-rs-b59eba162a2ae5a2/fd31571/src/documents/delete.rs:31:22
  20:        0x103c47760 - jetasap::syncd::sync_fs_to_pg::{{closure}}::hca28a09d418899b5
                               at /Users/vbeffa/jetasap/v2/srvr/src/syncd.rs:82:22
  21:        0x103c510a0 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h2096229e7485e072
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/future/mod.rs:80:19
  22:        0x103c4567e - jetasap::syncd::_run::{{closure}}::h74430b5df74edd8c
                               at /Users/vbeffa/jetasap/v2/srvr/src/syncd.rs:48:25
  23:        0x103c56220 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hed0c643aa0e3f6bf
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/future/mod.rs:80:19
  24:        0x103c43e41 - jetasap::syncd::run::{{closure}}::h3c680471fb0888d7
                               at /Users/vbeffa/jetasap/v2/srvr/src/syncd.rs:15:5
  25:        0x103c55c80 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::he23060f0fc7755d1
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/future/mod.rs:80:19
  26:        0x103dd33a0 - <futures_util::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll::hdd9615172393dea5
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.15/src/future/maybe_done.rs:95:38
  27:        0x103db85f6 - jetasap::main::main::{{closure}}::{{closure}}::h872d44821df90096
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.15/src/async_await/join_mod.rs:97:13
  28:        0x103ca8a82 - <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll::hec11b662881756ff
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.15/src/future/poll_fn.rs:56:9
  29:        0x103db94da - jetasap::main::main::{{closure}}::h4957fcf37a7f92e9
                               at /Users/vbeffa/jetasap/v2/srvr/src/main.rs:42:14
  30:        0x103c55b60 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::he105f4093bf95de0
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/future/mod.rs:80:19
  31:        0x103db8451 - jetasap::main::{{closure}}::h3f13e5f0b47cf79a
                               at /Users/vbeffa/jetasap/v2/srvr/src/main.rs:22:1
  32:        0x103c51500 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h32f1edb636753daf
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/future/mod.rs:80:19
  33:        0x103d32685 - <async_std::task::builder::SupportTaskLocals<F> as core::future::future::Future>::poll::{{closure}}::hdd03d6b47a527162
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/builder.rs:199:17
  34:        0x103c99313 - async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current::{{closure}}::h3b2638accb451e00
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/task_locals_wrapper.rs:60:13
  35:        0x103c319c5 - std::thread::local::LocalKey<T>::try_with::h459422527bbcd18b
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/thread/local.rs:400:16
  36:        0x103c305ac - std::thread::local::LocalKey<T>::with::hafe51f607bd2085a
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/thread/local.rs:376:9
  37:        0x103c98ec4 - async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current::he0f84de4d3befae9
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/task_locals_wrapper.rs:55:9
  38:        0x103d3212e - <async_std::task::builder::SupportTaskLocals<F> as core::future::future::Future>::poll::h62c257f0780c2477
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/builder.rs:197:13
  39:        0x103da8479 - <futures_lite::future::Or<F1,F2> as core::future::future::Future>::poll::h9db4ad326066fea7
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-lite-1.12.0/src/future.rs:526:33
  40:        0x103d3acfb - async_executor::Executor::run::{{closure}}::hec12812932f532f6
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-executor-1.4.1/src/lib.rs:242:9
  41:        0x103c511c0 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h26e36632d09bd45d
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/future/mod.rs:80:19
  42:        0x103d39c68 - async_executor::LocalExecutor::run::{{closure}}::hd0c2c6a1c97bd902
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-executor-1.4.1/src/lib.rs:447:9
  43:        0x103c52ee0 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h6cce36b57425115a
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/future/mod.rs:80:19
  44:        0x103dc3753 - async_io::driver::block_on::h337f9ea340e28de8
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-io-1.4.1/src/driver.rs:142:33
  45:        0x103ca64c1 - async_global_executor::reactor::block_on::{{closure}}::h910b28e96d67be5c
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/reactor.rs:3:18
  46:        0x103ca63e9 - async_global_executor::reactor::block_on::hbd0dc3588c5a729d
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/reactor.rs:12:5
  47:        0x103d97aa9 - async_global_executor::executor::block_on::{{closure}}::h9612eadd5a28a0df
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/executor.rs:26:36
  48:        0x103c323fc - std::thread::local::LocalKey<T>::try_with::h91c50af38be9174e
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/thread/local.rs:400:16
  49:        0x103c30530 - std::thread::local::LocalKey<T>::with::ha9a88e7179e89ac9
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/thread/local.rs:376:9
  50:        0x103d97958 - async_global_executor::executor::block_on::ha1bc60fc0978a62b
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-global-executor-2.0.2/src/executor.rs:26:5
  51:        0x103d37359 - async_std::task::builder::Builder::blocking::{{closure}}::{{closure}}::h4370727779e82796
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/builder.rs:171:25
  52:        0x103c999ad - async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current::{{closure}}::ha1f82cb84c1b30b3
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/task_locals_wrapper.rs:60:13
  53:        0x103c3118c - std::thread::local::LocalKey<T>::try_with::h2307ab408b454c6b
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/thread/local.rs:400:16
  54:        0x103c2fe50 - std::thread::local::LocalKey<T>::with::h288b597c485955ec
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/thread/local.rs:376:9
  55:        0x103c98bce - async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current::h6c77cd9129a724f1
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/task_locals_wrapper.rs:55:9
  56:        0x103d37032 - async_std::task::builder::Builder::blocking::{{closure}}::h85d338bb8af79ccd
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/builder.rs:168:17
  57:        0x103c332bc - std::thread::local::LocalKey<T>::try_with::hdf4ec56f1c2954fc
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/thread/local.rs:400:16
  58:        0x103c300c0 - std::thread::local::LocalKey<T>::with::h5baa51d7a37ab402
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/thread/local.rs:376:9
  59:        0x103d3659f - async_std::task::builder::Builder::blocking::h1990ce74ebf39e02
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/builder.rs:161:9
  60:        0x103d66154 - async_std::task::block_on::block_on::hc5c80cba8eee77e7
                               at /Users/vbeffa/.cargo/registry/src/github.com-1ecc6299db9ec823/async-std-1.9.0/src/task/block_on.rs:33:5
  61:        0x103d5d8c4 - jetasap::main::h7c09f28dd4ecf00d
                               at /Users/vbeffa/jetasap/v2/srvr/src/main.rs:22:1
  62:        0x103cf6b0e - core::ops::function::FnOnce::call_once::h22a7d1188e94ec90
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/ops/function.rs:227:5
  63:        0x103d38c21 - std::sys_common::backtrace::__rust_begin_short_backtrace::hcd1bf1f88da3a499
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/sys_common/backtrace.rs:125:18
  64:        0x103d5cdd4 - std::rt::lang_start::{{closure}}::hdda00c0185cfbbd4
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/rt.rs:49:18
  65:        0x104e07eb1 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::hf1ac1a73d60a0e8a
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/core/src/ops/function.rs:259:13
  66:        0x104e07eb1 - std::panicking::try::do_call::h640ea9013f052e81
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/panicking.rs:401:40
  67:        0x104e07eb1 - std::panicking::try::hd99dfa7f582cbb85
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/panicking.rs:365:19
  68:        0x104e07eb1 - std::panic::catch_unwind::habcde3ed72e26756
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/panic.rs:434:14
  69:        0x104e07eb1 - std::rt::lang_start_internal::he1efc3a0c46d0a91
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/rt.rs:34:21
  70:        0x103d5cdae - std::rt::lang_start::h0f36909df12b52c7
                               at /rustc/ed597e7e19d0fe716d9f81b1e840a5abbfd7c28d/library/std/src/rt.rs:48:5
  71:        0x103d5d936 - _main
```